### PR TITLE
상위 컴포넌트에서 정의한 `color` CSS 속성을 `<Txt />` 가 상속받지 못하는 버그 수정

### DIFF
--- a/src/components/atoms/Text.tsx
+++ b/src/components/atoms/Text.tsx
@@ -80,6 +80,7 @@ export interface TxtProps extends HTMLAttributes<HTMLSpanElement> {
 export const Txt = ({
   size = 'typo4',
   weight = 'medium',
+  color = 'inherit',
   marginBottom = 0,
   children,
   ...props

--- a/src/components/atoms/Text.tsx
+++ b/src/components/atoms/Text.tsx
@@ -74,20 +74,18 @@ const StyledTxt = styled.span<TxtProps>`
 export interface TxtProps extends HTMLAttributes<HTMLSpanElement> {
   size?: 'typo1' | 'typo2' | 'typo3' | 'typo4' | 'typo5' | 'typo6' | 'display1' | 'display2';
   weight?: 'bold' | 'medium' | 'regular';
-  color?: string;
   marginBottom?: number;
 }
 
 export const Txt = ({
   size = 'typo4',
   weight = 'medium',
-  color = '#333',
   marginBottom = 0,
   children,
   ...props
 }: TxtProps) => {
   return (
-    <StyledTxt size={size} weight={weight} color={color} marginBottom={marginBottom} {...props}>
+    <StyledTxt size={size} weight={weight} marginBottom={marginBottom} {...props}>
       {children}
     </StyledTxt>
   );


### PR DESCRIPTION
### 변경 개요
<!--
작업 내용의 목적과 변경 사항을 대략적으로 작성해주세요
-->

상위 컴포넌트에서 정의한 `color` CSS 속성을 `<Txt />` 가 상속받지 못하는 버그 수정

### 구현 내용
<!--
다음과 같은 구현에 대한 자세한 내용을 작성해주세요
- 추가하거나 수정한 주요 클래스 또는 컴포넌트
- 새로운 알고리즘이나 복잡한 모듈의 대략적인 설명
- 기존 아키텍처 또는 데이터 흐름에 대한 중대한 변경 사항
-->

`<Txt />` 컴포넌트에서 `color` 매개변수를 별도로 관리하지 않기

### 관련 이슈
<!--
resolved: #1 #2 #3
-->

- resolved: #42