### PR TITLE
main page에 있는 swiper 이미지 위치 조정

### DIFF
--- a/src/components/organisms/main/InfoMatchingBlock.tsx
+++ b/src/components/organisms/main/InfoMatchingBlock.tsx
@@ -15,7 +15,6 @@ const Block = styled.div`
   margin: 258px 0 290px;
 `;
 const CardSwiper = styled(Swiper)`
-  pointer-events: none;
   padding: 30px 0;
 
   .swiper-slide {
@@ -101,7 +100,7 @@ export const InfoMatchingBlock = () => {
                 imgUrl={card.imgUrl}
                 imgWidth={card.imgWidth}
                 imgHeight={card.imgHeight}
-                // imgLeftPx={card.imgLeftPx}
+                imgLeftPx={card.imgLeftPx}
               />
             </SwiperSlide>
           );


### PR DESCRIPTION
### 변경 개요
버전 차이로 props 적용을 못해서 이번에 추가함

### 구현 내용
`<MainDescriptionCard />`에서 imgLeftPx 추가
swiper 유저가 움직일 수 있게 수정

### 관련 이슈
resolved: #64
