### PR TITLE
유저 데이터 정보가 새로고침 시 사라지는 버그 수정

### DIFF
--- a/src/app/login-guard.tsx
+++ b/src/app/login-guard.tsx
@@ -14,7 +14,6 @@ import { useAuthStore } from '#/stores/auth';
 import { SignUpStep, PolicyAgreement, User } from '#/types';
 import { checkSignUpStep } from '#/utilities/check-sign-up-step';
 import { fitFetcher } from '#/utilities/fetch';
-import { getTokens } from '#/utilities/session';
 
 interface LoginGuardProps {
   children: React.ReactNode;

--- a/src/app/login-guard.tsx
+++ b/src/app/login-guard.tsx
@@ -12,6 +12,7 @@ import { SignUpTermsPopup } from '#/components/organisms/SignUpTermsPopup';
 import { policies } from '#/entities';
 import { useAuthStore } from '#/stores/auth';
 import { SignUpStep, PolicyAgreement, User } from '#/types';
+import { getTokens } from '#/utilities';
 import { checkSignUpStep } from '#/utilities/check-sign-up-step';
 import { fitFetcher } from '#/utilities/fetch';
 
@@ -37,7 +38,8 @@ export const LoginGuard: React.FC<LoginGuardProps> = ({ children }) => {
 
   useEffect(() => {
     async function fetchAuth() {
-      if (tokens) {
+      const currentToken = getTokens() ?? tokens;
+      if (currentToken) {
         const user = await fetchUser();
         const policyAgreed = await fetchPolicyAgreed();
         setAuth({ user, tokens, policyAgreed });

--- a/src/components/organisms/HeaderContent.tsx
+++ b/src/components/organisms/HeaderContent.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import { HeaderUserBlock } from '#/components/molecules/HeaderUserBlock';
 import { useAuthStore } from '#/stores/auth';
+import { getTokens } from '#/utilities';
 import { HeaderLoginBlock } from '#molecules/HeaderLoginBlock';
 import { HeaderLogo } from '#molecules/HeaderLogo';
 import { HeaderNav } from '#molecules/HeaderNav';
@@ -19,12 +20,13 @@ const ContentBlock = styled.div`
 `;
 
 export const HeaderContent = () => {
-  const user = useAuthStore((store) => store.user);
+  const tokens = getTokens();
+
   return (
     <ContentBlock>
       <HeaderLogo />
       <HeaderNav />
-      {user ? <HeaderUserBlock /> : <HeaderLoginBlock />}
+      {tokens ? <HeaderUserBlock /> : <HeaderLoginBlock />}
     </ContentBlock>
   );
 };

--- a/src/components/templates/LoginCallback.tsx
+++ b/src/components/templates/LoginCallback.tsx
@@ -49,7 +49,7 @@ export const LoginCallback = ({ platform }: LoginCallbackProps) => {
         const tokens = await acquireTokens({ platform, code });
         setStorageTokens(tokens);
         setStoreTokens(tokens);
-        router.replace('/');
+        location.href = '/';
       }
     }
     loadTokens();

--- a/src/components/templates/LoginCallback.tsx
+++ b/src/components/templates/LoginCallback.tsx
@@ -49,7 +49,7 @@ export const LoginCallback = ({ platform }: LoginCallbackProps) => {
         const tokens = await acquireTokens({ platform, code });
         setStorageTokens(tokens);
         setStoreTokens(tokens);
-        router.push('/');
+        router.replace('/');
       }
     }
     loadTokens();

--- a/src/components/templates/LoginCallback.tsx
+++ b/src/components/templates/LoginCallback.tsx
@@ -49,7 +49,7 @@ export const LoginCallback = ({ platform }: LoginCallbackProps) => {
         const tokens = await acquireTokens({ platform, code });
         setStorageTokens(tokens);
         setStoreTokens(tokens);
-        location.href = '/';
+        router.push('/');
       }
     }
     loadTokens();

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
 import { AuthTokens } from '#/types';
 import { User } from '#/types/user';
@@ -18,15 +19,22 @@ interface AuthAction {
   clear: () => void;
 }
 
-export const useAuthStore = create<AuthState & AuthAction>((set) => ({
-  user: null,
-  tokens: null,
-  policyAgreed: null,
+export const useAuthStore = create(
+  persist<AuthState & AuthAction>(
+    (set) => ({
+      user: null,
+      tokens: null,
+      policyAgreed: null,
 
-  setUser: (user) => set({ user }),
-  setTokens: (tokens) => set({ tokens }),
-  setPolicyAgreed: (policyAgreed) => set({ policyAgreed }),
+      setUser: (user) => set({ user }),
+      setTokens: (tokens) => set({ tokens }),
+      setPolicyAgreed: (policyAgreed) => set({ policyAgreed }),
 
-  set: (state) => set(state),
-  clear: () => set({ user: null, tokens: null, policyAgreed: null }),
-}));
+      set: (state) => set(state),
+      clear: () => set({ user: null, tokens: null, policyAgreed: null }),
+    }),
+    {
+      name: 'auth-storage',
+    }
+  )
+);

--- a/src/utilities/session.ts
+++ b/src/utilities/session.ts
@@ -3,7 +3,7 @@ import { AuthTokens } from '#/types/auth-tokens';
 const TOKENS_KEY = 'api-token';
 
 export function getTokens(): AuthTokens | null {
-  const tokens = sessionStorage.getItem(TOKENS_KEY);
+  const tokens = typeof window !== 'undefined' ? sessionStorage.getItem(TOKENS_KEY) : null;
   if (tokens) {
     return JSON.parse(tokens);
   }


### PR DESCRIPTION
### 변경 개요
새로고침 시 auth store의 정보가 사라짐
token이 있는 상태를 확인하고 다시 user 정보를 가져오는 방법으로 하려다가 그러면 시간이 오래걸려서 로그인이 안된것처럼 보일 때가 순간 있음
그래서 store 정보를 새로고침해도 유지하는 방향으로 수정했음

### 구현 내용
- auth store에 persist 추가
- header 로그인 확인 부분 token으로 확인하게 수정

### 관련 이슈
resolved: #88 
