### PR TITLE
약관 동의 안되던 버그 수정

### DIFF
--- a/src/components/organisms/SignUpProfileCreationPopup.tsx
+++ b/src/components/organisms/SignUpProfileCreationPopup.tsx
@@ -5,11 +5,11 @@ import styled from '@emotion/styled';
 
 import { useShallow } from 'zustand/react/shallow';
 
+import { uploadImageToS3 } from '#/hooks/use-file';
 import { usePresignedUrlQuery } from '#/hooks/use-presigned-url';
 import { useUserMutation } from '#/hooks/use-user';
 import { useAuthStore } from '#/stores/auth';
 import { User } from '#/types/user';
-import { uploadProfileImage } from '#/utilities/storage';
 import { Button } from '../atoms/Button';
 import { Icons } from '../atoms/Icons';
 import { Input } from '../atoms/Input';
@@ -99,17 +99,19 @@ export const SignUpProfileCreationPopup: React.FC<SignUpProfileCreationPopupProp
     if (imageFile) {
       const { preSignedUrl, fileKey } = await getPresignedUrl({
         fileDomain: 'PROFILE_IMAGE',
-        fileName: `profile-${user?.id}`,
+        fileName: imageFile.name,
       });
-      await uploadProfileImage({ imageFile, preSignedUrl });
+      await uploadImageToS3(preSignedUrl, imageFile);
       userInfo.profileImageUrl = fileKey;
     }
     setUser(await mutateUser(userInfo));
     return onSuccess();
-  }, [getPresignedUrl, mutateUser, nickname, onSuccess, setUser, user?.id]);
+  }, [getPresignedUrl, mutateUser, nickname, onSuccess, setUser]);
 
   useEffect(() => {
-    setPreviewImage(user?.profileImageUrl ?? null);
+    setPreviewImage(
+      user?.profileImageUrl ? process.env.NEXT_PUBLIC_S3_IMAGE_URL + user?.profileImageUrl : null
+    );
   }, [user?.profileImageUrl]);
 
   useEffect(() => {

--- a/src/components/organisms/SignUpTermsPopup.tsx
+++ b/src/components/organisms/SignUpTermsPopup.tsx
@@ -43,10 +43,18 @@ export const SignUpTermsPopup: React.FC<SignUpTermsPopupProps> = ({ onSuccess })
 
   useEffect(() => {
     if (allAgreed && !isMutatingAgreements) {
+      updateAgreements(
+        policyAgrees.map((agree) => ({ type: agree.type, isAgree: agree.isAgree })),
+        {
+          optimisticData: {
+            policyAgreementList: policyAgrees,
+          },
+        }
+      );
       setAgreed(true);
       onSuccess();
     }
-  }, [allAgreed, isMutatingAgreements, onSuccess, setAgreed]);
+  }, [allAgreed, isMutatingAgreements, onSuccess, policyAgrees, setAgreed, updateAgreements]);
 
   useEffect(() => {
     if (policyAgrees.length > 0) {


### PR DESCRIPTION
### 변경 개요
모두 동의합니다 클릭 시 term api가 호출 되지 않는 버그 발견

### 구현 내용
- 모두 동의합니다 클릭 시  모든 term 동의합니다로 api post 보내게 수정
- 첫 프로필 등록에서 프로필이 제대로 등록되지 않던 버그 수정

### 관련 이슈
resolved: #89
