### PR TITLE
fix, 포트폴리오 삭제 안되는 버그 수정

### DIFF
--- a/src/components/templates/MyPage/InfoEditSection.tsx
+++ b/src/components/templates/MyPage/InfoEditSection.tsx
@@ -39,7 +39,7 @@ export const InfoEditSection = ({ handleEditing }: InfoEditSectionProps) => {
 
   const submitModifyHandler = async () => {
     let profileImageUrl = user?.profileImageUrl;
-    let portfolioUrl: string | null = null;
+    let portfolioUrl: string = '';
     if (tempImage !== null) {
       const registerImage = await mutatePreSignedUrl({
         fileName: tempImage.name,
@@ -49,7 +49,7 @@ export const InfoEditSection = ({ handleEditing }: InfoEditSectionProps) => {
       profileImageUrl = registerImage.fileKey;
     }
     if (user?.portfolioUrl !== null && tempPortfolioFile === null) {
-      portfolioUrl = null;
+      portfolioUrl = '';
     } else if (tempPortfolioFile !== null) {
       const registerPortfolio = await mutatePreSignedUrl({
         fileName: tempPortfolioFile.name,
@@ -62,8 +62,9 @@ export const InfoEditSection = ({ handleEditing }: InfoEditSectionProps) => {
     const mutated = await mutateUser({
       ...tempUser,
       profileImageUrl: profileImageUrl,
-      portfolioUrl: portfolioUrl,
+      portfolioUrl: '',
     });
+    console.log(mutated);
     setUser(mutated);
     initTempAuth();
     handleEditing();


### PR DESCRIPTION
### 변경 개요
마이페이지에서 포트폴리오 삭제 시 삭제가 안되던 버그 수정
null로 보낼 시 적용이 안됨 -> null 대신 빈 string으로 보내게 수정

### 구현 내용
- 포트폴리오 삭제 안되던 버그 수정

### 관련 이슈
resolved: #96 
