### PR TITLE
첫 회원가입 사용 가능한 툴에서 position 잘리는 문제 해결

### DIFF
--- a/src/components/organisms/sign-up/ToolAvailabilitySubmission.tsx
+++ b/src/components/organisms/sign-up/ToolAvailabilitySubmission.tsx
@@ -51,6 +51,7 @@ const PositionTabs = styled.div`
   overflow-x: auto;
   display: flex;
   gap: 10px;
+
   padding: 10px;
 `;
 


### PR DESCRIPTION
### 변경 개요
<img width="1624" alt="image" src="https://github.com/Team-Crops/fit-web/assets/58589176/5f58b423-46db-40f6-8bb2-04d38514a776">
첫 회원가입에서 포지션 오른쪽 짤리는 문제 

### 구현 내용
- 포지션 짤리는 부분 `overflow-x: auto`추가

### 관련 이슈
resolved: #98
