### PR TITLE
헤더 프로필 모달 너비 조정

### DIFF
--- a/src/components/atoms/Icons.tsx
+++ b/src/components/atoms/Icons.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import Image from 'next/image';
 
+import styled from '@emotion/styled';
+
 import {
   AccountIcon,
   ArrowDown,
@@ -319,7 +321,7 @@ export const Icons: React.FC<IconsProps> = ({
   }
 
   return (
-    <div {...props}>
+    <Container {...props}>
       {useCSSColor ? (
         <SVGR width={size ?? width} height={size ?? height} style={{ ...style, flexShrink: 0 }} />
       ) : (
@@ -330,6 +332,10 @@ export const Icons: React.FC<IconsProps> = ({
           style={{ ...style, flexShrink: 0 }}
         />
       )}
-    </div>
+    </Container>
   );
 };
+
+const Container = styled.div`
+  display: contents;
+`;

--- a/src/components/molecules/HeaderMenuModal.tsx
+++ b/src/components/molecules/HeaderMenuModal.tsx
@@ -13,33 +13,29 @@ const MenuModal = styled.div`
   right: 0;
   bottom: -218px;
 
-  width: 250px;
   height: 190px;
-  padding: 25px 20px 20px;
+  padding: 24px;
 
   background: #fff;
   border-radius: 4px;
   box-shadow: 0 0 40px 0 rgb(0 0 0 / 10%);
 `;
 const SummaryBlock = styled.div`
-  display: block;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 2px 0;
 `;
 const TopBlock = styled.div`
   display: flex;
-  gap: 13px;
+  gap: 12px;
 `;
 const FlexBlock = styled.div`
   display: flex;
-  gap: 10px;
+  gap: 8px;
   align-items: center;
-
-  width: 147px;
-  margin-bottom: 4px;
 `;
 const UserName = styled(Txt)`
-  overflow: hidden;
-  text-overflow: ellipsis;
-  word-break: break-all;
   white-space: nowrap;
 `;
 const Position = styled(Txt)`
@@ -47,13 +43,12 @@ const Position = styled(Txt)`
   align-items: center;
   justify-content: center;
 
-  height: 22px;
-  padding: 0 17px;
+  padding: 2px 16px;
 
   white-space: nowrap;
 
   background-color: #ffeae9;
-  border-radius: 33px;
+  border-radius: 100px;
 `;
 const LinkListBlock = styled.div`
   display: flex;
@@ -102,7 +97,7 @@ export const HeaderMenuModal = ({ isOpen, toggleMenu }: HeaderMenuModalProps) =>
             </Position>
           </FlexBlock>
           <FlexBlock>
-            <Icons icon={'email'} width={15} height={15} color="#757575" />
+            <Icons icon={'email'} size={16} color="#757575" />
             <Txt size="typo6" weight="regular" color="#757575">
               {me?.email}
             </Txt>
@@ -112,13 +107,13 @@ export const HeaderMenuModal = ({ isOpen, toggleMenu }: HeaderMenuModalProps) =>
 
       <LinkListBlock>
         <LinkBlock href={'/mypage'} onClick={toggleMenu}>
-          <Icons icon={'userLine'} width={20} height={20} color="#FF706C" />
+          <Icons icon={'userLine'} size={20} color="#FF706C" />
           <Txt size="typo6" weight="regular" color="#212121">
             마이페이지로 이동
           </Txt>
         </LinkBlock>
         <LinkBlock href={'/mypage'} onClick={handleLogout}>
-          <Icons icon={'logout'} width={20} height={20} color="#FF706C" />
+          <Icons icon={'logout'} size={20} color="#FF706C" />
           <Txt size="typo6" weight="regular" color="#212121">
             로그아웃
           </Txt>

--- a/src/components/molecules/HeaderUserBlock.tsx
+++ b/src/components/molecules/HeaderUserBlock.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 
 import styled from '@emotion/styled';
 

--- a/src/components/organisms/ProfileBlock.tsx
+++ b/src/components/organisms/ProfileBlock.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, ChangeEventHandler, InputHTMLAttributes, useCallback, useState } from 'react';
+import { ChangeEvent, useCallback, useState } from 'react';
 import Image from 'next/image';
 
 import styled from '@emotion/styled';


### PR DESCRIPTION
### 변경 개요
<!--
작업 내용의 목적과 변경 사항을 대략적으로 작성해주세요
-->

- #173 

<img width="277" alt="image" src="https://github.com/Team-Crops/fit-web/assets/49232918/68a597a2-0b4d-4840-a8d9-26463351245a">

<img width="284" alt="image" src="https://github.com/Team-Crops/fit-web/assets/49232918/14e1a4bb-76b4-4a2b-b5ac-a2c2396be51b">

### 구현 내용
<!--
다음과 같은 구현에 대한 자세한 내용을 작성해주세요
- 추가하거나 수정한 주요 클래스 또는 컴포넌트
- 새로운 알고리즘이나 복잡한 모듈의 대략적인 설명
- 기존 아키텍처 또는 데이터 흐름에 대한 중대한 변경 사항
-->

- `HeaderMenuModal` 컴포넌트의 고정된 `width` 값 삭제
- 아이콘 정렬을 위해 `Icons` 컴포넌트의 `<SVGR />` 상위 `<div />` 에 `display: content` 속성 추가
- `<SummaryBlock />` 상하에 통일된 여백을 갖도록 수정

### 관련 이슈
<!--
resolved: #1 #2 #3
-->

- close: #173