### PR TITLE
fix, 다른 페이지 접근 시 router.push("/")로 수정

### DIFF
--- a/src/app/login-guard.tsx
+++ b/src/app/login-guard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { Loading } from '#/components/atoms';
@@ -17,13 +18,15 @@ export const LoginGuard = ({ children }: LoginGuardProps) => {
   const { isLoading, error } = useMeQuery();
   const showLoginPopup = useLoginGuardStore((state) => state.showLoginPopup);
 
+  useEffect(() => {
+    if (error && error.code === ApiError.INVALID_ACCESS_TOKEN_CODE) {
+      router.push('/');
+      showLoginPopup();
+    }
+  }, [error]);
+
   if (isLoading) {
     return <Loading />;
-  }
-
-  if (error && error.code === ApiError.INVALID_ACCESS_TOKEN_CODE) {
-    showLoginPopup();
-    router.back();
   }
 
   return (


### PR DESCRIPTION
### 변경 개요
router.back()으로 하니 페이지가 새로고침돼서 로그인 팝업이 없어짐
다른 페이지에서 우리 페이지로 접근 시 back되면 다른페이지로 다시 나감
이 이유로 router.push("/")가 더 좋다고 생각했습니당
근데 push로 바꾸니 아래와 같은 에러가 떠서 useEffect로 감쌌고 return보다 useEffect가 아래 있을 수 없어서 코드 수정했습니다.
<img width="599" alt="image" src="https://github.com/Team-Crops/fit-web/assets/58589176/94f30f4c-8279-4b83-a358-dd39940b0900">

### 구현 내용
- 다른 페이지 접근 시 router.push("/")로 수정
- useEffect 추가 및 위치 수정

### 관련 이슈
resolved: ##208 