### PR TITLE
로그아웃 시 캐시된 모든 데이터 삭제

### DIFF
--- a/src/components/atoms/Link.tsx
+++ b/src/components/atoms/Link.tsx
@@ -4,15 +4,14 @@ import Link from 'next/link';
 
 import { useMeQuery } from '#/hooks/use-user';
 import { useLoginGuardStore } from '#/stores';
-import { ApiError } from '#/types';
 
 export const GuardedLink = (props: Parameters<typeof Link>[0]) => {
   const showLoginPopup = useLoginGuardStore((state) => state.showLoginPopup);
 
-  const { error } = useMeQuery();
+  const { data: me } = useMeQuery();
 
-  if (error && error.code === ApiError.INVALID_ACCESS_TOKEN_CODE) {
-    return <span {...props} onClick={() => showLoginPopup()} />;
+  if (me) {
+    return <Link {...props} />;
   }
-  return <Link {...props} />;
+  return <span {...props} onClick={() => showLoginPopup()} />;
 };

--- a/src/components/molecules/HeaderMenuModal.tsx
+++ b/src/components/molecules/HeaderMenuModal.tsx
@@ -3,6 +3,8 @@ import Link from 'next/link';
 
 import styled from '@emotion/styled';
 
+import { mutate } from 'swr';
+
 import { usePositionsQuery } from '#/hooks/use-positions';
 import { useMeQuery } from '#/hooks/use-user';
 import { Icons, Txt } from '../atoms';
@@ -70,14 +72,13 @@ interface HeaderMenuModalProps {
 }
 export const HeaderMenuModal = ({ isOpen, toggleMenu }: HeaderMenuModalProps) => {
   const { data: positions } = usePositionsQuery();
-  const { data: me, mutate: mutateMe } = useMeQuery();
+  const { data: me } = useMeQuery();
 
-  const handleLogout = useCallback(() => {
+  const handleLogout = useCallback(async () => {
     localStorage.clear();
-    mutateMe(undefined, false);
-    location.href = '/';
+    mutate(() => true, undefined, { revalidate: false });
     toggleMenu();
-  }, [mutateMe, toggleMenu]);
+  }, [toggleMenu]);
 
   if (!isOpen) return null;
   return (


### PR DESCRIPTION
### 변경 개요
<!--
작업 내용의 목적과 변경 사항을 대략적으로 작성해주세요
-->

- `<GuardedLink />` 가 `me` 데이터를 사용하도록 수정해 `me` 를 쿼리할 수 없는 상황에는 로그인 컴포넌트를 보도록 수정
- 로그아웃 시 캐시된 모든 데이터 삭제하기
	- 캐시된 `me` 데이터를 삭제해 `<GuardedLink />` 를 다시 렌더링

### 구현 내용
<!--
다음과 같은 구현에 대한 자세한 내용을 작성해주세요
- 추가하거나 수정한 주요 클래스 또는 컴포넌트
- 새로운 알고리즘이나 복잡한 모듈의 대략적인 설명
- 기존 아키텍처 또는 데이터 흐름에 대한 중대한 변경 사항
-->

- `mutate(() => true, undefined, { revalidate: false })`
	- 캐시된 모든 데이터를 선택해 `undefined` 로 초기화하고 다시 쿼리를 보내지 않음
	- https://github.com/vercel/swr/discussions/1494

### 관련 이슈
<!--
resolved: #1 #2 #3
-->

- #207 