### PR TITLE
메시지 버블 시간 처리하는 로직 수정

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: false,
   compiler: {
     emotion: true,
   },

--- a/src/components/molecules/ChatBubble.tsx
+++ b/src/components/molecules/ChatBubble.tsx
@@ -17,7 +17,13 @@ interface ChatBubbleProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 export const ChatBubble = ({ user, message, myBubble = false, ...props }: ChatBubbleProps) => {
-  const plainTime = useMemo(() => Temporal.PlainTime.from(message.createdAt), [message.createdAt]);
+  const plainTime = useMemo(
+    () =>
+      Temporal.Instant.from(message.createdAt)
+        .toZonedDateTimeISO(Temporal.Now.zonedDateTimeISO())
+        .toPlainTime(),
+    [message.createdAt]
+  );
   return (
     <Container myBubble={myBubble}>
       <ColoredProfile imageUrl={user.profileImageUrl} nickname={user.nickname} size={40} />

--- a/src/components/molecules/ChatParticipant.tsx
+++ b/src/components/molecules/ChatParticipant.tsx
@@ -62,7 +62,7 @@ export const ChatParticipant = ({
           )}
         </UserProfileContainer>
       )}
-      <Nickname size="typo5" weight="medium" color="rgba(33, 33, 33, 1)">
+      <Nickname size="typo5" weight="medium" color="#212121">
         {nickname ?? ''}
       </Nickname>
       {userId && showDetails && (


### PR DESCRIPTION
### 변경 개요
<!--
작업 내용의 목적과 변경 사항을 대략적으로 작성해주세요
-->

- #221 

> https://tc39.es/proposal-temporal/docs/plaintime.html#static-methods
>
> Any non-object value will be converted to a string, which is expected to be in ISO 8601 format. If the string designates a date, it will be ignored. Time zone or UTC offset information will also be ignored, with one exception: if a string contains a Z in place of a numeric UTC offset, then a RangeError will be thrown because interpreting these strings as a local time is usually a bug. Temporal.Instant.from should be used instead to parse these strings, and the result's toZonedDateTimeISO method can be used to obtain a timezone-local date and time.
>
> In unusual cases of needing date or time components of Z-terminated timestamp strings (e.g. daily rollover of a UTC-timestamped log file), use the time zone 'UTC'. For example, the following code returns a "UTC time": Temporal.Instant.from(thing).toZonedDateTimeISO('UTC').toPlainTime().

### 구현 내용
<!--
다음과 같은 구현에 대한 자세한 내용을 작성해주세요
- 추가하거나 수정한 주요 클래스 또는 컴포넌트
- 새로운 알고리즘이나 복잡한 모듈의 대략적인 설명
- 기존 아키텍처 또는 데이터 흐름에 대한 중대한 변경 사항
-->

- `Temporal.PlainTime.from()` 대신 `Temporal.Instant.from().toZonedDateTimeISO().toPlainTime()` 사용
	```ts
	// From docs: Temporal.Instant.from(thing).toZonedDateTimeISO('UTC').toPlainTime()
	const plainTime = Temporal.Instant.from(thing)
	  .toZonedDateTimeISO(
	    Temporal.Now.zonedDateTimeISO()
	  )
	  .toPlainTime()
	```

### 관련 이슈
<!--
resolved: #1 #2 #3
-->

- close: #221 