### PR TITLE
회원가입 할 때 프로젝트 경험 수 선택하지 않아도 기본으로 없음이 들어가게 변경

### DIFF
--- a/src/components/atoms/Select.tsx
+++ b/src/components/atoms/Select.tsx
@@ -255,7 +255,7 @@ export const Select: React.FC<SelectProps> & {
       <SelectContainer className={className} ref={containerRef} width={width}>
         <input type="text" readOnly value={value} style={{ display: 'none' }} {...props} />
         <SelectButton error={error} value={value} onClick={() => setOpened((prev) => !prev)}>
-          {(value && label) ?? placeholder}
+          {((value !== null || value !== undefined) && label) ?? placeholder}
           <ArrowIcon icon="arrowDown" size={12} $isError={error} $isOpened={isOpened} />
           <OptionList position={optionsPosition} hidden={!isOpened} ref={optionsRef}>
             {children}

--- a/src/components/organisms/sign-up/TimeAvailabilitySubmission.tsx
+++ b/src/components/organisms/sign-up/TimeAvailabilitySubmission.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+
 import styled from '@emotion/styled';
 
 import { Icons } from '#/components/atoms/Icons';
@@ -44,6 +46,12 @@ export const TimeAvailabilitySubmission: React.FC<TimeAvailabilitySubmissionProp
   onUserModified,
 }) => {
   const { data: regions } = useRegionsQuery();
+
+  // init
+  useEffect(() => {
+    onUserModified({ projectCount: 0 });
+  }, []);
+
   return (
     <Container>
       <TitleContainer>

--- a/src/components/organisms/sign-up/TimeAvailabilitySubmission.tsx
+++ b/src/components/organisms/sign-up/TimeAvailabilitySubmission.tsx
@@ -50,7 +50,7 @@ export const TimeAvailabilitySubmission: React.FC<TimeAvailabilitySubmissionProp
   // init
   useEffect(() => {
     onUserModified({ projectCount: 0 });
-  }, []);
+  }, [onUserModified]);
 
   return (
     <Container>


### PR DESCRIPTION
### 변경 개요
select의 value 값이 없을 때 label이 제대로 노출 되지 않는 문제가 있음
ex) projectCount가 0일 때 없음으로 나와야 하는데 0으로 노출되는 문제

### 구현 내용
- select의 value 가 null이나 undefined이 아닐 때 label 노출되게 수정
- 회원가입할 때 기본값으로 projectCount가 0으로 설정

### 관련 이슈
resolved: #237
