### PR TITLE
Select 버그 수정

### DIFF
--- a/src/components/atoms/Select.tsx
+++ b/src/components/atoms/Select.tsx
@@ -13,6 +13,8 @@ import { Children, createContext, useContext, useEffect, useMemo, useRef, useSta
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
+import { isNil } from 'lodash';
+
 import { transientStyled } from '#/utilities/transient-styled';
 import { Icons } from '#atoms/Icons';
 
@@ -253,15 +255,9 @@ export const Select: React.FC<SelectProps> & {
   return (
     <SelectContext.Provider value={{ value, onChange, setLabel }}>
       <SelectContainer className={className} ref={containerRef} width={width}>
-        <input
-          type="text"
-          readOnly
-          value={value === undefined ? '' : value}
-          style={{ display: 'none' }}
-          {...props}
-        />
+        <input type="text" readOnly value={value ?? ''} style={{ display: 'none' }} {...props} />
         <SelectButton error={error} value={value} onClick={() => setOpened((prev) => !prev)}>
-          {value === null || value === undefined ? placeholder : label}
+          {isNil(value) ? placeholder : label}
           <ArrowIcon icon="arrowDown" size={12} $isError={error} $isOpened={isOpened} />
           <OptionList position={optionsPosition} hidden={!isOpened} ref={optionsRef}>
             {children}

--- a/src/components/atoms/Select.tsx
+++ b/src/components/atoms/Select.tsx
@@ -253,9 +253,15 @@ export const Select: React.FC<SelectProps> & {
   return (
     <SelectContext.Provider value={{ value, onChange, setLabel }}>
       <SelectContainer className={className} ref={containerRef} width={width}>
-        <input type="text" readOnly value={value} style={{ display: 'none' }} {...props} />
+        <input
+          type="text"
+          readOnly
+          value={value === undefined ? '' : value}
+          style={{ display: 'none' }}
+          {...props}
+        />
         <SelectButton error={error} value={value} onClick={() => setOpened((prev) => !prev)}>
-          {((value !== null || value !== undefined) && label) ?? placeholder}
+          {value === null || value === undefined ? placeholder : label}
           <ArrowIcon icon="arrowDown" size={12} $isError={error} $isOpened={isOpened} />
           <OptionList position={optionsPosition} hidden={!isOpened} ref={optionsRef}>
             {children}


### PR DESCRIPTION
### 변경 개요
- 팀원 추천에서 필터를 선택한 후 필터 초기화를 눌러도 label이 계속 남아있던 버그
- `<Select />` 선택 시 콘솔에 에러 발생

### 구현 내용
- `<Select />`의 value가 null이나 undefined일 경우 placeholder가 보이게 수정
- `<Select />`의 value가 input에 들어갈 때 undefined로 들어가지 않게 수정

### 관련 이슈
resolved: #244 #245
